### PR TITLE
Update from compile to implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ on Gradle Metadata. Depending on your platform (JS or JVM) the correct
 artifact will be imported.
 
 ```groovy
-    compile 'io.data2viz.geojson:core:0.6.2'
+implementation 'io.data2viz.geojson:core:0.6.2'
 ```
 
 The JS version is available in [both modes](https://kotlinlang.org/docs/reference/js-ir-compiler.html), `Legacy` and `IR`.


### PR DESCRIPTION
Updates to README, because `compile` has been deprecated in Gradle